### PR TITLE
Feat/delete my card

### DIFF
--- a/client/src/components/Card/DeleteCardModal.jsx
+++ b/client/src/components/Card/DeleteCardModal.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import Loading from "../Loading";
+
+const DeleteCardModal = ({
+  isDeleteModalOpen,
+  setIsDeleteModalOpen,
+  deleteCardHandler,
+  isDeleteLoading,
+}) => {
+  const closeModal = () => {
+    setIsDeleteModalOpen(false);
+  };
+
+  
+
+  if (!isDeleteModalOpen) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50 transition-opacity duration-300 ease-in-out">
+      <div className="bg-white p-6 rounded-lg shadow-lg w-full max-w-lg transform transition-transform duration-300 ease-in-out">
+        <div className="flex justify-end mb-1">
+          <img
+            src="/assets/exit.png"
+            alt="exit-icon"
+            className="w-6 h-6 hover:cursor-pointer"
+            onClick={closeModal}
+          />
+        </div>
+        <div className="flex flex-col items-center gap-10 p-4">
+          <div className="flex flex-col items-center gap-2">
+            <p className="text-lg font-medium">카드를 삭제하시겠어요?</p>
+          </div>
+          <div className="w-full flex flex-row justify-center gap-3">
+            <button
+              className="border border-gray-300 rounded font-medium w-5/12 h-12"
+              onClick={closeModal}
+            >
+              취소
+            </button>
+            <button
+              className="rounded font-medium w-5/12 h-12 bg-amber-500 text-white"
+              onClick={deleteCardHandler}
+            >
+              {isDeleteLoading ? (
+                <Loading width="w-10" height="h-10" padding="p-2" />
+              ) : (
+                "확인"
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DeleteCardModal;

--- a/client/src/service/cardService.js
+++ b/client/src/service/cardService.js
@@ -8,14 +8,7 @@ export const getMyCard = async () => {
 
   const response = await api.get(`/api/card`, headersConfig);
 
-  const myCard = response.data.card;
-
-  // 카드 정보가 있으면 첫 번째 정보 리턴, 없으면 서버가 보내준 빈 배열 리턴
-  if (myCard.length === 0) {
-    return myCard;
-  } else {
-    return myCard[0];
-  }
+  return response.data.card;
 };
 
 export const saveCard = async (newCardInfo) => {

--- a/client/src/service/cardService.js
+++ b/client/src/service/cardService.js
@@ -1,15 +1,14 @@
 import { getAxiosHeaderConfig } from "../config";
 import { api } from "../api/api";
 
+const headersConfig = getAxiosHeaderConfig();
+
 export const getMyCard = async () => {
-  const headersConfig = getAxiosHeaderConfig();
-  if (!headersConfig) return null;
+  if (!headersConfig) return;
 
   const response = await api.get(`/api/card`, headersConfig);
 
   const myCard = response.data.card;
-
-  console.log("내 카드 조회 데이터 확인", myCard);
 
   // 카드 정보가 있으면 첫 번째 정보 리턴, 없으면 서버가 보내준 빈 배열 리턴
   if (myCard.length === 0) {
@@ -20,10 +19,17 @@ export const getMyCard = async () => {
 };
 
 export const saveCard = async (newCardInfo) => {
-  const headersConfig = getAxiosHeaderConfig();
   if (!headersConfig) return;
 
-  const response = await api.post(`/api/card`, newCardInfo, headersConfig);
+  const response = await api.post("/api/card", newCardInfo, headersConfig);
 
   return response.data.savedCard;
+};
+
+export const deleteCard = async (cardId) => {
+  if (!headersConfig) return;
+
+  const response = await api.delete(`/api/card/${cardId}`, headersConfig);
+
+  return response.data;
 };

--- a/client/src/utils/algorithm/fisherYatesShuffle.js
+++ b/client/src/utils/algorithm/fisherYatesShuffle.js
@@ -1,4 +1,4 @@
-const fisherYatesShuffle = async (array) => {
+const fisherYatesShuffle = (array) => {
   // 가져온 api의 data 그 자체를 바꿔서 리턴할 수 없으므로 복제하기
   let duplicatedArray = [...array];
 

--- a/client/src/utils/algorithm/luhnCheck.js
+++ b/client/src/utils/algorithm/luhnCheck.js
@@ -1,6 +1,5 @@
 export const luhnCheck = (cardNumber) => {
   // 카드 등록 때 카드번호는 문자열 "0000 0000 0000 0000" 형식으로 받아옵니다
-
   if (!cardNumber) return false;
 
   const removedSpaceBetweenNumbers = cardNumber.replace(/\s/g, "");
@@ -10,7 +9,6 @@ export const luhnCheck = (cardNumber) => {
   const sum = digits.reduce((accumulator, digit, index) => {
     if (index % 2 !== 0) {
       let doubled = digit * 2;
-
       if (doubled > 9) {
         doubled -= 9;
       }

--- a/server/controllers/cardController.js
+++ b/server/controllers/cardController.js
@@ -37,6 +37,32 @@ export const saveCard = async (req, res) => {
     });
   } catch (error) {
     console.log("카드 저장 중 에러 발생", error);
-    res.status(500).send("카드 저장 중에 에러가 발생했습니다.");
+    return res.status(500).send("카드 저장 중에 에러가 발생했습니다.");
+  }
+};
+
+export const deleteCard = async (req, res) => {
+  const userId = req.userId;
+  const { cardId } = req.params;
+
+  try {
+    const existCardForUserId = await Card.findOne({ user_id: userId });
+
+    if (!existCardForUserId) {
+      return res.status(404).send("해당 사용자의 저장된 카드가 없습니다.");
+    }
+
+    if (existCardForUserId._id.toString() === cardId) {
+      await Card.deleteOne({ _id: cardId });
+
+      return res.status(200).json({
+        message: "해당 사용자의 카드가 성공적으로 삭제되었습니다.",
+      });
+    } else {
+      return res.status(404).send("해당 카드가 존재하지 않습니다.");
+    }
+  } catch (error) {
+    console.error("카드 삭제 중 오류 발생", error);
+    return res.status(500).send("카드 삭제 중 에러가 발생했습니다.");
   }
 };

--- a/server/routes/cardRoutes.js
+++ b/server/routes/cardRoutes.js
@@ -1,9 +1,14 @@
 import express from "express";
-import { getMyCard, saveCard } from "../controllers/cardController.js";
+import {
+  deleteCard,
+  getMyCard,
+  saveCard,
+} from "../controllers/cardController.js";
 import { verifyToken } from "../middleware/auth.js";
 const router = express.Router();
 
 router.get("/", verifyToken, getMyCard);
 router.post("/", verifyToken, saveCard);
+router.delete("/:cardId", verifyToken, deleteCard);
 
 export default router;


### PR DESCRIPTION
- 마이페이지에서 내 카드 삭제를 위한 API 로직을 서버 컨트롤러에서 구현 및 라우트 적용 완성했습니다.
- 클라이언트에서 내 카드 삭제를 위한 API 요청 로직을 cardService에 추가하였습니다.
- MyCardInfo 컴포넌트에서 삭제 버튼을 눌렀을 시, 삭제 확인 모달을 띄웁니다
- 삭제 확인 모달에서 확인 버튼을 누르면, useMutation을 통해 카드 삭제 API 함수가 호출됩니다. 
- 마이페이지에서 기존 카드 삭제 후, 새로운 카드를 추가했을 시 뜨지 않던 카드 번호 버그를 useEffect 내 조건문 추가 후 고쳤습니다. 